### PR TITLE
add escape '\' (fix issue #12)

### DIFF
--- a/autoload/rufo.vim
+++ b/autoload/rufo.vim
@@ -61,7 +61,7 @@ function! s:format(start_line, end_line) abort
     silent exec l:buffer_number . 'bdelete'
   endif
 
-  let l:selection = join(getline(a:start_line, a:end_line), '\n')
+  let l:selection = join(map(getline(a:start_line, a:end_line), "escape(v:val, '\\')"), '\n')
   let l:out = systemlist('echo ' . shellescape(l:selection) . '| rufo')
   return [s:formatting_failed(l:out), l:out]
 endf


### PR DESCRIPTION
fix isssue https://github.com/ruby-formatter/rufo-vim/issues/12