### PR TITLE
add g:rufo_silence_errors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ For formatting some part of the code select lines with Shift+V and call `:Rufo` 
 `g:rufo_errors_buffer_position` - errors buffer position. Possible values: 'top', 'bottom', 'left', 'right'.
 Default: 'bottom'
 
+`g:rufo_silence_errors` - Errors will not be shown if set to `1`. Possible values: 0 or 1. Default: 0
+
 ## Commands
 
 `:Rufo` - run formatting. In Normal mode - format whole file, in Visual mode - format selected part

--- a/autoload/rufo.vim
+++ b/autoload/rufo.vim
@@ -71,6 +71,11 @@ function! s:formatting_failed(message) abort
 endf
 
 function! s:show_error(message) abort
+  " Don't open buffer if the errors should be silent
+  if g:rufo_silence_errors == 1
+    return
+  endif
+
   let l:buffer_position = get(s:buffer_positions, g:rufo_errors_buffer_position, s:buffer_positions.bottom)
   let l:buffer_number = bufnr(s:default_buffer_name)
 

--- a/plugin/rufo.vim
+++ b/plugin/rufo.vim
@@ -12,6 +12,10 @@ if !exists('g:rufo_errors_buffer_position')
   let g:rufo_errors_buffer_position = 'bottom'
 endif
 
+if !exists('g:rufo_silence_errors')
+  let g:rufo_silence_errors = 0
+endif
+
 function! s:init_commands()
   command! -nargs=0 -range=0 Rufo call rufo#Format(<line1>, <line2>, <count>)
   command! RufoOn let g:rufo_auto_formatting = 1


### PR DESCRIPTION
Hi!

I quickly added an option to **not** show the error buffer if an error occurs while running `rufo`.

###  But ... why?

I have set rufo autoformatting to 1 so it formats the current file once I `:w` it.
In case of broken/incomplete ruby files the rufo error buffer is way to large for my taste and really doesn't help since I use the Ale linter to check for errors.

Thanks you for this vim integration!

Cheers!

![rufo-vim-silence_errors-why](https://user-images.githubusercontent.com/100459/37101657-64cc70a4-2226-11e8-8f5b-329b25828ffd.png)
(Not to scale 😄 )
