### PR TITLE
Check shell return code in addition to output

### DIFF
--- a/autoload/rufo.vim
+++ b/autoload/rufo.vim
@@ -63,11 +63,11 @@ function! s:format(start_line, end_line) abort
 
   let l:selection = join(map(getline(a:start_line, a:end_line), "escape(v:val, '\\')"), '\n')
   let l:out = systemlist('echo ' . shellescape(l:selection) . '| rufo')
-  return [s:formatting_failed(l:out), l:out]
+  return [s:formatting_failed(v:shell_error, l:out), l:out]
 endf
 
-function! s:formatting_failed(message) abort
-  return a:message[0] =~ 'Error'
+function! s:formatting_failed(status, message) abort
+  return (a:status && a:status != 3) || a:message[0] =~# 'Error'
 endf
 
 function! s:show_error(message) abort

--- a/autoload/rufo.vim
+++ b/autoload/rufo.vim
@@ -63,11 +63,11 @@ function! s:format(start_line, end_line) abort
 
   let l:selection = join(map(getline(a:start_line, a:end_line), "escape(v:val, '\\')"), '\n')
   let l:out = systemlist('echo ' . shellescape(l:selection) . '| rufo')
-  return [s:formatting_failed(v:shell_error, l:out), l:out]
+  return [s:formatting_failed(v:shell_error), l:out]
 endf
 
-function! s:formatting_failed(status, message) abort
-  return (a:status && a:status != 3) || a:message[0] =~# 'Error'
+function! s:formatting_failed(status) abort
+  return a:status && a:status != 3
 endf
 
 function! s:show_error(message) abort


### PR DESCRIPTION
When the `rufo` command does not exist, or outputs something with a non-success exit code, the current failure check considers the run as successful, replacing the original buffer with the error message.

By checking the command return code (`v:shell_error`), it correctly displays the message in the error buffer and keeps the original buffer intact.

