### PR TITLE
Set error buffer as nomodified

### DIFF
--- a/autoload/rufo.vim
+++ b/autoload/rufo.vim
@@ -99,7 +99,7 @@ function! s:show_error(message) abort
     setlocal buftype=nofile bufhidden=hide nobuflisted noswapfile
   endif
   silent exec line('$') . 'delete _'
-  setlocal nomodifiable
+  setlocal nomodifiable nomodified
 endf
 
 func! s:replace(start_line, end_line, text) abort


### PR DESCRIPTION
If formatting is run twice and in both times errors were shown in the error buffer, on the second run the error buffer will get the `modified` status, which will bug the user about the buffer not being saved (for example when exiting with `:qa`).