### PR TITLE
Fix text sent as input to rufo

### DIFF
--- a/autoload/rufo.vim
+++ b/autoload/rufo.vim
@@ -61,7 +61,7 @@ function! s:format(start_line, end_line) abort
     silent exec l:buffer_number . 'bdelete'
   endif
 
-  let l:selection = join(map(getline(a:start_line, a:end_line), "escape(v:val, '\\')"), "\n")
+  let l:selection = join(getline(a:start_line, a:end_line), "\n")
   let l:out = systemlist('echo ' . shellescape(l:selection) . '| rufo')
   return [s:formatting_failed(l:out), l:out]
 endf

--- a/autoload/rufo.vim
+++ b/autoload/rufo.vim
@@ -61,7 +61,7 @@ function! s:format(start_line, end_line) abort
     silent exec l:buffer_number . 'bdelete'
   endif
 
-  let l:selection = join(map(getline(a:start_line, a:end_line), "escape(v:val, '\\')"), '\n')
+  let l:selection = join(map(getline(a:start_line, a:end_line), "escape(v:val, '\\')"), "\n")
   let l:out = systemlist('echo ' . shellescape(l:selection) . '| rufo')
   return [s:formatting_failed(l:out), l:out]
 endf


### PR DESCRIPTION
The text being sent to `rufo` is incorrectly formed with lines joined by the actual characters `\n`, instead of an actual single-char newline.

This fixes #17 and fixes #18.