### PR TITLE
fix: literal newline "\n" escape

### DIFF
--- a/autoload/rufo.vim
+++ b/autoload/rufo.vim
@@ -62,7 +62,7 @@ function! s:format(start_line, end_line) abort
   endif
 
   let l:selection = join(getline(a:start_line, a:end_line), "\n")
-  let l:out = systemlist('echo ' . shellescape(l:selection) . '| rufo')
+  let l:out = systemlist('printf %s ' . shellescape(l:selection) . '| rufo')
   return [s:formatting_failed(v:shell_error), l:out]
 endf
 


### PR DESCRIPTION
related to https://github.com/ruby-formatter/rufo-vim/issues/28

The echo command treats "\n" from selection as non-literal string, which
causes one-line string like "hello\nworld" becoming two lines. Using
`printf %s` preserves it as one line.